### PR TITLE
Update for Ruby 3 keyword arguments behaviour

### DIFF
--- a/lib/i18n_multitenant.rb
+++ b/lib/i18n_multitenant.rb
@@ -21,13 +21,13 @@ module I18nMultitenant
   #   I18nMultitenant.set(locale: :es)
   #   => :es
   def self.set(options)
-    I18n.locale = locale_for(options)
+    I18n.locale = locale_for(**options)
   end
 
   # Public: Executes block using the specified locale configuration, restoring
   # it after the block is executed.
   def self.with_locale(options)
-    I18n.with_locale(locale_for(options)) { yield }
+    I18n.with_locale(locale_for(**options)) { yield }
   end
 
   # Internal: Get the internal locale for a tenant-specific locale.


### PR DESCRIPTION
Passing in keyword arguments using a hash as the last parameter does not
work in Ruby 3. This updates the library to work on Ruby > 3.

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/